### PR TITLE
feat: replacing redness restart to graceful reload with fifo

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -46,22 +46,12 @@
   "configProvider": "CONFIG_PROVIDER",
   "updatedTimeJsonFilePath": "UPDATED_TIME_JSON_FILE_PATH",
   "yamlDestinationFilePath": "YAML_DESTINATION_FILE_PATH",
+  "uwsgiFifoFilePath": "UWSGI_FIFO_FILE_PATH",
+
   "poll": {
     "timeout": {
       "frequencyMilliseconds": {
         "__name": "POLL_TIMEOUT_FREQUENCY_MS",
-        "__format": "number"
-      },
-      "readinessKillMaxRandomSeconds": {
-        "__name": "POLL_TIMEOUT_READINESS_KILL_MAX_RND_SECONDS",
-        "__format": "number"
-      },
-      "requestsKillSeconds": {
-        "__name": "POLL_TIMEOUT_REQUESTS_KILL_SECONDS",
-        "__format": "number"
-      },
-      "afterUpdateDelaySeconds": {
-        "__name": "POLL_TIMEOUT_AFTER_UPDATE_DELAY_SECONDS",
         "__format": "number"
       }
     }

--- a/config/default.json
+++ b/config/default.json
@@ -30,12 +30,10 @@
   "updatedTimeFileName": "updated_time.json",
   "updatedTimeJsonFilePath": "/path/to/existing/updated_time.json",
   "yamlDestinationFilePath": "/path/to/destination/mapproxy.yaml",
+  "uwsgiFifoFilePath": "/path/to/fifo/file",
   "poll": {
     "timeout": {
-      "frequencyMilliseconds": 5000,
-      "readinessKillMaxRandomSeconds": 300,
-      "requestsKillSeconds": 5,
-      "afterUpdateDelaySeconds": 0.5
+      "frequencyMilliseconds": 5000
     }
   },
   "FS": {

--- a/config/test.json
+++ b/config/test.json
@@ -3,7 +3,7 @@
   "updatedTimeJsonFilePath": "tests/unit/mock/updated_time.json",
   "poll": {
     "timeout": {
-      "readinessKillMaxRandomSeconds": 1
+      "frequencyMilliseconds": 1
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "pg": "^8.6.0",
         "reflect-metadata": "^0.1.13",
         "swagger-ui-express": "^4.1.6",
-        "tsyringe": "^4.7.0"
+        "tsyringe": "^4.7.0",
+        "zx": "^4.2.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.4",
@@ -3152,7 +3153,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3164,7 +3164,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3172,7 +3171,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -5444,6 +5442,14 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/generic-pool": {
       "version": "3.8.1",
       "deprecated": "This is a stub types definition. generic-pool provides its own type definitions, so you do not need this installed.",
@@ -5617,9 +5623,9 @@
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
     },
     "node_modules/@types/mongodb": {
       "version": "3.6.20",
@@ -5646,6 +5652,15 @@
     "node_modules/@types/node": {
       "version": "14.18.21",
       "license": "MIT"
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -6496,7 +6511,6 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -6896,7 +6910,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -7070,7 +7083,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7227,7 +7239,6 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8244,7 +8255,6 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8316,7 +8326,6 @@
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
@@ -8400,6 +8409,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "node_modules/duplexify": {
       "version": "4.1.2",
@@ -9362,6 +9376,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "node_modules/event-stream/node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "license": "MIT",
@@ -9596,9 +9635,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -9735,7 +9774,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -9858,7 +9896,6 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -9896,6 +9933,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "node_modules/fs-extra": {
       "version": "11.1.1",
@@ -10158,7 +10200,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -10280,7 +10321,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -10343,7 +10383,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10533,7 +10572,6 @@
     },
     "node_modules/ignore": {
       "version": "5.2.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -10776,7 +10814,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10799,7 +10836,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -10837,7 +10873,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -11055,7 +11090,6 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -11841,7 +11875,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -12200,6 +12233,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "license": "MIT",
@@ -12283,7 +12321,6 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -12298,7 +12335,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
@@ -12511,7 +12547,6 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -12530,17 +12565,14 @@
     },
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -12992,10 +13024,17 @@
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dependencies": {
+        "through": "~2.3"
       }
     },
     "node_modules/pg": {
@@ -13072,7 +13111,6 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -13591,6 +13629,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.0",
       "license": "MIT",
@@ -14102,7 +14154,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14667,6 +14718,14 @@
         "npm": ">=6"
       }
     },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
     "node_modules/stream-shift": {
       "version": "1.0.1",
       "license": "MIT"
@@ -14895,7 +14954,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -14973,7 +15031,6 @@
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/through2": {
@@ -15030,7 +15087,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -15338,7 +15394,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -15686,6 +15741,103 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zx": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-4.3.0.tgz",
+      "integrity": "sha512-KuEjpu5QFIMx0wWfzknDRhY98s7a3tWNRmYt19XNmB7AfOmz5zISA4+3Q8vlJc2qguxMn89uSxhPDCldPa3YLA==",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.12",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^16.6",
+        "@types/node-fetch": "^2.5.12",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.0.0",
+        "globby": "^12.0.1",
+        "minimist": "^1.2.5",
+        "node-fetch": "^2.6.1",
+        "ps-tree": "^1.2.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "zx": "zx.mjs"
+      },
+      "engines": {
+        "node": ">= 14.13.1"
+      }
+    },
+    "node_modules/zx/node_modules/@types/node": {
+      "version": "16.18.68",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+      "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
+    },
+    "node_modules/zx/node_modules/array-union": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zx/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zx/node_modules/globby": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
+      "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
+      "dependencies": {
+        "array-union": "^3.0.1",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.7",
+        "ignore": "^5.1.9",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zx/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zx/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   },
@@ -17683,19 +17835,16 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
       }
     },
     "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true
+      "version": "2.0.5"
     },
     "@nodelib/fs.walk": {
       "version": "1.2.8",
-      "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -19186,6 +19335,14 @@
         "@types/send": "*"
       }
     },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/generic-pool": {
       "version": "3.8.1",
       "requires": {
@@ -19332,8 +19489,9 @@
       "dev": true
     },
     "@types/minimist": {
-      "version": "1.2.0",
-      "dev": true
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
     },
     "@types/mongodb": {
       "version": "3.6.20",
@@ -19356,6 +19514,15 @@
     },
     "@types/node": {
       "version": "14.18.21"
+    },
+    "@types/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -19868,8 +20035,7 @@
       }
     },
     "asynckit": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -20138,7 +20304,6 @@
     },
     "braces": {
       "version": "3.0.2",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -20230,7 +20395,6 @@
     },
     "chalk": {
       "version": "4.1.2",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -20317,7 +20481,6 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -21007,8 +21170,7 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "depd": {
       "version": "2.0.0"
@@ -21046,7 +21208,6 @@
     },
     "dir-glob": {
       "version": "3.0.1",
-      "dev": true,
       "requires": {
         "path-type": "^4.0.0"
       }
@@ -21100,6 +21261,11 @@
           "dev": true
         }
       }
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
     },
     "duplexify": {
       "version": "4.1.2",
@@ -21707,6 +21873,30 @@
     "etag": {
       "version": "1.8.1"
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      },
+      "dependencies": {
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+          "requires": {
+            "through": "2"
+          }
+        }
+      }
+    },
     "event-target-shim": {
       "version": "5.0.1"
     },
@@ -21866,8 +22056,9 @@
       "version": "3.1.3"
     },
     "fast-glob": {
-      "version": "3.2.12",
-      "dev": true,
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -21972,7 +22163,6 @@
     },
     "fill-range": {
       "version": "7.0.1",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -22061,7 +22251,6 @@
     },
     "form-data": {
       "version": "4.0.0",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -22083,6 +22272,11 @@
     },
     "fresh": {
       "version": "0.5.2"
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
     },
     "fs-extra": {
       "version": "11.1.1",
@@ -22251,7 +22445,6 @@
     },
     "glob-parent": {
       "version": "5.1.2",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -22324,8 +22517,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.11",
-      "dev": true
+      "version": "4.2.11"
     },
     "graphemer": {
       "version": "1.4.0",
@@ -22360,8 +22552,7 @@
       "dev": true
     },
     "has-flag": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -22472,8 +22663,7 @@
       "version": "1.1.13"
     },
     "ignore": {
-      "version": "5.2.4",
-      "dev": true
+      "version": "5.2.4"
     },
     "import-fresh": {
       "version": "3.2.1",
@@ -22617,8 +22807,7 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1",
-      "dev": true
+      "version": "2.1.1"
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0"
@@ -22629,7 +22818,6 @@
     },
     "is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -22647,8 +22835,7 @@
       "dev": true
     },
     "is-number": {
-      "version": "7.0.0",
-      "dev": true
+      "version": "7.0.0"
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -22766,8 +22953,7 @@
       "version": "1.0.0"
     },
     "isexe": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -23310,7 +23496,6 @@
     },
     "jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
@@ -23555,6 +23740,11 @@
       "version": "4.1.0",
       "dev": true
     },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
     "media-typer": {
       "version": "0.3.0"
     },
@@ -23610,15 +23800,13 @@
       "dev": true
     },
     "merge2": {
-      "version": "1.4.1",
-      "dev": true
+      "version": "1.4.1"
     },
     "methods": {
       "version": "1.1.2"
     },
     "micromatch": {
       "version": "4.0.5",
-      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -23748,22 +23936,18 @@
     },
     "node-fetch": {
       "version": "2.6.7",
-      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       },
       "dependencies": {
         "tr46": {
-          "version": "0.0.3",
-          "dev": true
+          "version": "0.0.3"
         },
         "webidl-conversions": {
-          "version": "3.0.1",
-          "dev": true
+          "version": "3.0.1"
         },
         "whatwg-url": {
           "version": "5.0.0",
-          "dev": true,
           "requires": {
             "tr46": "~0.0.3",
             "webidl-conversions": "^3.0.0"
@@ -24050,8 +24234,15 @@
       "version": "0.1.7"
     },
     "path-type": {
-      "version": "4.0.0",
-      "dev": true
+      "version": "4.0.0"
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "requires": {
+        "through": "~2.3"
+      }
     },
     "pg": {
       "version": "8.6.0",
@@ -24099,8 +24290,7 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "dev": true
+      "version": "2.3.1"
     },
     "pify": {
       "version": "2.3.0",
@@ -24413,6 +24603,14 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
+    },
     "pump": {
       "version": "3.0.0",
       "requires": {
@@ -24716,7 +24914,6 @@
     },
     "run-parallel": {
       "version": "1.2.0",
-      "dev": true,
       "requires": {
         "queue-microtask": "^1.2.2"
       }
@@ -25093,6 +25290,14 @@
     "stoppable": {
       "version": "1.1.0"
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
     "stream-shift": {
       "version": "1.0.1"
     },
@@ -25240,7 +25445,6 @@
     },
     "supports-color": {
       "version": "7.2.0",
-      "dev": true,
       "requires": {
         "has-flag": "^4.0.0"
       }
@@ -25287,8 +25491,7 @@
       }
     },
     "through": {
-      "version": "2.3.8",
-      "dev": true
+      "version": "2.3.8"
     },
     "through2": {
       "version": "4.0.2",
@@ -25328,7 +25531,6 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -25492,8 +25694,7 @@
       "dev": true
     },
     "universalify": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.0"
     },
     "unpipe": {
       "version": "1.0.0"
@@ -25700,6 +25901,72 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
+    },
+    "zx": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-4.3.0.tgz",
+      "integrity": "sha512-KuEjpu5QFIMx0wWfzknDRhY98s7a3tWNRmYt19XNmB7AfOmz5zISA4+3Q8vlJc2qguxMn89uSxhPDCldPa3YLA==",
+      "requires": {
+        "@types/fs-extra": "^9.0.12",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^16.6",
+        "@types/node-fetch": "^2.5.12",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.0.0",
+        "globby": "^12.0.1",
+        "minimist": "^1.2.5",
+        "node-fetch": "^2.6.1",
+        "ps-tree": "^1.2.0",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "16.18.68",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.68.tgz",
+          "integrity": "sha512-sG3hPIQwJLoewrN7cr0dwEy+yF5nD4D/4FxtQpFciRD/xwUzgD+G05uxZHv5mhfXo4F9Jkp13jjn0CC2q325sg=="
+        },
+        "array-union": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
+          "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "globby": {
+          "version": "12.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-12.2.0.tgz",
+          "integrity": "sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==",
+          "requires": {
+            "array-union": "^3.0.1",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.7",
+            "ignore": "^5.1.9",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "pg": "^8.6.0",
     "reflect-metadata": "^0.1.13",
     "swagger-ui-express": "^4.1.6",
-    "tsyringe": "^4.7.0"
+    "tsyringe": "^4.7.0",
+    "zx": "^4.2.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.4",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -23,9 +23,6 @@ export interface IUpdatedTimeFileContentResult {
 export interface IPollConfig {
   timeout: {
     frequencyMilliseconds: number;
-    readinessKillMaxRandomSeconds: number;
-    requestsKillSeconds: number;
-    afterUpdateDelaySeconds: number;
   };
 }
 

--- a/src/pollManager.ts
+++ b/src/pollManager.ts
@@ -1,40 +1,35 @@
 import { Logger } from '@map-colonies/js-logger';
-import { inject, singleton } from 'tsyringe';
+import { $ } from 'zx';
+import { container, inject, singleton } from 'tsyringe';
 import { Watcher } from './watcher';
-import { Readiness } from './probe/readiness';
 import { Services } from './common/constants';
-import { IConfigProvider, IPollConfig } from './common/interfaces';
+import { IConfig, IConfigProvider, IPollConfig } from './common/interfaces';
 
 @singleton()
 export class PollManager {
+  private readonly config: IConfig;
   public constructor(
     @inject(Services.LOGGER) private readonly logger: Logger,
     @inject(Services.POLLCONFIG) private readonly pollCofig: IPollConfig,
     @inject(Services.CONFIGPROVIDER) private readonly configProvider: IConfigProvider,
     private readonly watcher: Watcher,
-    private readonly readiness: Readiness
-  ) {}
+  ) {
+    this.config = container.resolve(Services.CONFIG);
+  }
 
   public async poll(): Promise<void> {
     const frequencyTimeOutMS = this.pollCofig.timeout.frequencyMilliseconds;
-    const requestsKillSeconds = this.pollCofig.timeout.requestsKillSeconds;
-    const afterUpdateDelaySeconds = this.pollCofig.timeout.afterUpdateDelaySeconds;
 
     try {
       this.logger.info(`polling attempt`);
       if (!(await this.watcher.isUpdated())) {
         this.logger.debug('changes detected!');
-        const readinessKillRndInt = this.getRandomInteger();
-        this.logger.info(`killing readiness in ${readinessKillRndInt} seconds`);
-        await this.delay(readinessKillRndInt);
-        this.readiness.kill();
-        this.logger.info(`killing existing requests in ${requestsKillSeconds}`);
-        await this.delay(requestsKillSeconds);
+        this.logger.info(`killing worker by graceful reload in uwsgi app`);
+        await this.reloadApp();
+        this.logger.info(`reload request was sent, app will be reloaded`);
+
         this.logger.info('updating configurations');
         await this.configProvider.createOrUpdateConfigFile();
-        // make sure mapproxy start updating before restart readiness
-        await this.delay(afterUpdateDelaySeconds);
-        this.readiness.start();
       } else {
         this.logger.debug('no changes detected');
       }
@@ -49,14 +44,9 @@ export class PollManager {
     }, frequencyTimeOutMS);
   }
 
-  public async delay(seconds: number): Promise<void> {
-    const msToSeconds = 1000;
-    await new Promise((resolve) => setTimeout(resolve, seconds * msToSeconds));
+  public async reloadApp(): Promise<void> {
+    const fifoFilePath = this.config.get('uwsgiFifoFilePath');
+    await $ `echo r > ${fifoFilePath}`
   }
 
-  public getRandomInteger(): number {
-    const maxRandomSeconds = this.pollCofig.timeout.readinessKillMaxRandomSeconds;
-    const randomInt = Math.floor(Math.random() * maxRandomSeconds);
-    return randomInt;
-  }
 }

--- a/tests/unit/pollManager.spec.ts
+++ b/tests/unit/pollManager.spec.ts
@@ -3,20 +3,15 @@ import { Logger } from '@map-colonies/js-logger';
 import { registerTestValues } from '../integration/testContainerConfig';
 import { PollManager } from '../../src/pollManager';
 import { Watcher } from '../../src/watcher';
-import { Readiness } from '../../src/probe/readiness';
 import { Services } from '../../src/common/constants';
 import { IConfigProvider } from '../../src/common/interfaces';
 
 let pollManager: PollManager;
 let watcher: Watcher;
-let readiness: Readiness;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 let configProvider: IConfigProvider;
-let getRandomIntegerStub: jest.SpyInstance;
 let isUpdatedStub: jest.SpyInstance;
-let delayStub: jest.SpyInstance;
-let readinessKillStub: jest.SpyInstance;
-let readinessStartStub: jest.SpyInstance;
+let reloadStub: jest.SpyInstance;
 let createOrUpdateConfigFileStub: jest.SpyInstance;
 
 describe('pollManager', () => {
@@ -24,16 +19,12 @@ describe('pollManager', () => {
     registerTestValues();
     pollManager = container.resolve(PollManager);
     watcher = container.resolve(Watcher);
-    readiness = container.resolve(Readiness);
     configProvider = container.resolve(Services.CONFIGPROVIDER);
   });
 
   beforeEach(() => {
-    getRandomIntegerStub = jest.spyOn(pollManager, 'getRandomInteger');
     isUpdatedStub = jest.spyOn(watcher, 'isUpdated');
-    delayStub = jest.spyOn(pollManager, 'delay').mockImplementation(async () => Promise.resolve());
-    readinessKillStub = jest.spyOn(readiness, 'kill');
-    readinessStartStub = jest.spyOn(readiness, 'start');
+    reloadStub = jest.spyOn(pollManager, 'reloadApp').mockImplementation(async () => Promise.resolve());
     createOrUpdateConfigFileStub = jest.spyOn(configProvider, 'createOrUpdateConfigFile').mockResolvedValue(undefined);
     jest.useFakeTimers();
   });
@@ -44,33 +35,24 @@ describe('pollManager', () => {
 
   describe('poll', () => {
     it('should start a poll and not throw an error', async () => {
-      getRandomIntegerStub.mockReturnValue(5);
       isUpdatedStub.mockResolvedValue(true);
 
       const res = pollManager.poll();
       await expect(res).resolves.not.toThrow();
 
       expect(isUpdatedStub).toHaveBeenCalled();
-      expect(delayStub).toHaveBeenCalledTimes(0);
-      expect(getRandomIntegerStub).toHaveBeenCalledTimes(0);
-      expect(readinessKillStub).toHaveBeenCalledTimes(0);
       expect(createOrUpdateConfigFileStub).toHaveBeenCalledTimes(0);
-      expect(readinessStartStub).toHaveBeenCalledTimes(0);
+      expect(reloadStub).toHaveBeenCalledTimes(0);
     });
 
     it('should kill and restart readiness and not throw an error', async () => {
-      getRandomIntegerStub.mockReturnValue(5);
       isUpdatedStub.mockResolvedValue(false);
 
       const res = pollManager.poll();
       await expect(res).resolves.not.toThrow();
-
       expect(isUpdatedStub).toHaveBeenCalledTimes(1);
-      expect(delayStub).toHaveBeenCalledTimes(3);
-      expect(getRandomIntegerStub).toHaveBeenCalledTimes(1);
-      expect(readinessKillStub).toHaveBeenCalledTimes(1);
+      expect(reloadStub).toHaveBeenCalledTimes(1);
       expect(createOrUpdateConfigFileStub).toHaveBeenCalledTimes(1);
-      expect(readinessStartStub).toHaveBeenCalledTimes(1);
     });
 
     it('should reject and not to throw an error due to poll date error (watcher)', async () => {
@@ -78,28 +60,15 @@ describe('pollManager', () => {
         error: jest.fn(),
         info: jest.fn(),
       } as unknown as Logger;
-      pollManager = new PollManager(loggerMock, container.resolve(Services.POLLCONFIG), configProvider, watcher, readiness);
-      getRandomIntegerStub.mockReturnValue(5);
+      pollManager = new PollManager(loggerMock, container.resolve(Services.POLLCONFIG), configProvider, watcher);
       isUpdatedStub.mockRejectedValue(new Error('Error1'));
 
       await pollManager.poll();
 
       expect(loggerMock.error).toHaveBeenCalledTimes(1);
       expect(isUpdatedStub).toHaveBeenCalledTimes(1);
-      expect(delayStub).toHaveBeenCalledTimes(0);
-      expect(getRandomIntegerStub).toHaveBeenCalledTimes(0);
-      expect(readinessKillStub).toHaveBeenCalledTimes(0);
+      expect(reloadStub).toHaveBeenCalledTimes(0);
       expect(createOrUpdateConfigFileStub).toHaveBeenCalledTimes(0);
-      expect(readinessStartStub).toHaveBeenCalledTimes(0);
-    });
-
-    describe('getRandomInteger', () => {
-      it('should return random integer', () => {
-        const randomInt = pollManager.getRandomInteger();
-
-        expect(typeof randomInt).toBe('number');
-        expect(randomInt).toBeLessThanOrEqual(1);
-      });
     });
   });
 });


### PR DESCRIPTION
Implement UWSGI's built-in fifo functionallity and using graceful reload to update mapproxy yaml changes

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                      |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                       |
| Chore            | ✔/✖                                                                       |

using 'echo r > /some/fifo/file' will reload all uwsgi's workers and this will reload by rollout the app (mapproxy) 