### PR TITLE
fix: gracefulDelay will be taken from global

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -20,6 +20,6 @@ data:
   TELEMETRY_METRICS_URL: {{ $metricsUrl }}
   {{ end }}
   LOG_LEVEL: {{ .Values.env.logLevel | quote }}
-  GRACEFUL_RELOAD_MAX_SECONDS: {{ .Values.env.gracefulReloadMaxSeconds | quote }}
+  GRACEFUL_RELOAD_MAX_SECONDS: {{ .Values.global.gracefulReloadMaxSeconds | quote }}
   PGAPPNAME: {{ $chartName }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,6 +3,7 @@ global:
   tracing: {}
   metrics: {}
   environment: {}
+  gracefulReloadMaxSeconds: 300
 
 authentication:
   ca:
@@ -42,7 +43,6 @@ env:
   targetPort: 8080
   protocol: TCP
   logLevel: info
-  gracefulReloadMaxSeconds: 300
   logPrettyPrintEnabled: false
   responseCompressionEnabled: true
   requestPayloadLimit: 1mb


### PR DESCRIPTION
gracefulReloadMaxSeconds is shared to cache-seeder and mapproxinator - so it should be configured on Global scope for both

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
